### PR TITLE
Fix 404 error occurs when reload a page on pages excluding root #2

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,4 +33,10 @@ module.exports = {
     }),
     new Dotenv(),
   ],
+  output: {
+    publicPath: '/',
+  },
+  devServer: {
+    historyApiFallback: true,
+  },
 };


### PR DESCRIPTION
## Overview
Fix the bug by modifying the webpack config file.
Needs to use HTML5 History API, otherwise the page will be considered as not matching to any path

## Change
webpack.config.js

## Note
```
  output: {
    publicPath: '/',
  },
  devServer: {
    historyApiFallback: true,
  },
``` 
